### PR TITLE
fix: read dotenv files from root folder

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -120,6 +120,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>me.paulschwarz</groupId>
+			<artifactId>spring-dotenv</artifactId>
+			<version>4.0.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/service-user/src/main/resources/application.properties
+++ b/backend/service-user/src/main/resources/application.properties
@@ -14,6 +14,8 @@ spring.jpa.hibernate.ddl-auto=update
 # Logging
 logging.level.org.springframework.web=DEBUG
 
+dotenv.path=./.env
+
 # JWT secret key
 security.jwt.secretKey=${JWT_SECRET_KEY}
 security.jwt.expirationTime=3600000


### PR DESCRIPTION
### **Description:**  
This PR resolves an issue where the `.env` file was not being properly read into the `application.properties` configuration. The issue has been addressed by integrating the `spring-dotenv` library, which allows environment variables stored in the `.env` file to be loaded correctly into the Spring Boot application.

### **Changes Introduced:**
- Integrated the `spring-dotenv` library to enable reading from `.env` files from root folder.
- Specified the file path via `dotenv.path=./.env`.

### **Reason for Change:**
This fixes the issue of environment variables not being correctly injected into the Spring Boot application, ensuring that sensitive configurations (e.g., JWT secret keys, API keys) are properly read from the `.env` file.