### PR TITLE
Add filter question by difficulty and category

### DIFF
--- a/backend/service-question/src/main/java/g55/cs3219/backend/questionservice/repository/QuestionRepository.java
+++ b/backend/service-question/src/main/java/g55/cs3219/backend/questionservice/repository/QuestionRepository.java
@@ -12,5 +12,5 @@ public interface QuestionRepository extends MongoRepository<Question, Integer> {
     List<Question> findAll();
     List<Question> findByCategoriesContaining(String category);
     List<Question> findByDifficulty(String difficulty);
-
+    List<Question> findByCategoriesContainingAndDifficulty(String category, String difficulty);
 }

--- a/backend/service-question/src/main/java/g55/cs3219/backend/questionservice/service/QuestionService.java
+++ b/backend/service-question/src/main/java/g55/cs3219/backend/questionservice/service/QuestionService.java
@@ -46,15 +46,22 @@ public class QuestionService {
     }
 
     public List<QuestionDto> getQuestionsByFilters(String category, String difficulty) {
+        List<Question> questions;
         if (category != null && difficulty != null) {
-            throw new InvalidQuestionException("Cannot filter by both category and difficulty.");
+            questions = questionRepository.findByCategoriesContainingAndDifficulty(category, difficulty);
         } else if (category != null) {
-            return getQuestionsByCategory(category);
+            questions = questionRepository.findByCategoriesContaining(category);
         } else if (difficulty != null) {
-            return getQuestionsByDifficulty(difficulty);
+            questions = questionRepository.findByDifficulty(difficulty);
         } else {
             throw new InvalidQuestionException("At least one filter is required.");
         }
+    
+        if (questions.isEmpty()) {
+            throw new QuestionNotFoundException("No questions found with the given filters.");
+        }
+    
+        return questions.stream().map(this::convertToDTO).collect(Collectors.toList());
     }
 
     public List<QuestionDto> getQuestionsByDifficulty(String difficulty) {


### PR DESCRIPTION
## Description
Added filter to get questions to include combination of difficulty and category as previously only allowed for one filter parameters. This is so that `Question Service` can cater to `Matching Service` as users are matched based on the category and difficulty.

## ToDo
- [ ] Add Unit Test for filter