### PR TITLE
Add backend-service-matching to frontend's dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     depends_on:
       - backend-service-question
       - backend-service-user
+      - backend-service-matching
 
   backend-service-question:
     build:
@@ -81,8 +82,6 @@ services:
       SPRING_RABBITMQ_HOST: rabbitmq
       SPRING_RABBITMQ_PORT: 5672
     depends_on:
-      - backend-service-user
-      - backend-service-question
       - rabbitmq
 
   rabbitmq:


### PR DESCRIPTION
## What this PR does
* Added matching service to the frontend's dependencies.
* Removed user service and question service from matching service's dependencies.

## Why this was done:
* Frontend should wait for the matching service to start - to prevent users from matching before the service isn't ready.
* Matching service does not depend on the other two - can start concurrently together. 