### PR TITLE
Remove unused queue position UI

### DIFF
--- a/frontend/src/components/discuss/views/WaitingView.tsx
+++ b/frontend/src/components/discuss/views/WaitingView.tsx
@@ -5,12 +5,10 @@ import { Loader2, Timer } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 
 interface WaitingViewProps {
-  queuePosition: number;
   onCancel: () => void;
 }
 
 export const WaitingView: React.FC<WaitingViewProps> = ({
-  queuePosition,
   onCancel,
 }) => {
   const [elapsedTime, setElapsedTime] = useState(0);
@@ -42,7 +40,7 @@ export const WaitingView: React.FC<WaitingViewProps> = ({
           <Alert>
             <AlertTitle>Searching for a match</AlertTitle>
             <AlertDescription>
-              Your position in queue: {queuePosition}
+              Looking for available partners...
             </AlertDescription>
           </Alert>
           <div className='flex items-center justify-center space-x-2 text-sm text-muted-foreground'>

--- a/frontend/src/routes/discuss.tsx
+++ b/frontend/src/routes/discuss.tsx
@@ -21,7 +21,6 @@ import React, { useRef } from "react";
 
 export default function DiscussRoute() {
   const [matchStatus, setMatchStatus] = React.useState("idle");
-  const [queuePosition, setQueuePosition] = React.useState(0);
   const [roomId, setRoomId] = React.useState("");
 
   const auth = useAuth();
@@ -146,7 +145,6 @@ export default function DiscussRoute() {
   // Update resetState to use setupWebSocket
   const resetState = async () => {
     setMatchStatus(MATCH_IDLE_STATUS);
-    setQueuePosition(0);
     setRoomId("");
 
     // Close existing WebSocket connection
@@ -174,7 +172,7 @@ export default function DiscussRoute() {
         <IdleView onStartMatching={startMatching} />
       )}
       {matchStatus === MATCH_WAITING_STATUS && (
-        <WaitingView queuePosition={queuePosition} onCancel={cancelMatching} />
+        <WaitingView onCancel={cancelMatching} />
       )}
       {matchStatus === MATCH_FOUND_STATUS && (
         <MatchedView roomId={roomId} onNewMatch={resetState} />


### PR DESCRIPTION
- Removed the unused 'queuePosition' prop from the WaitingView component
- Updated the WaitingView component to display a message while searching for available partners
- Removed the 'queuePosition' state and related logic from the DiscussRoute component
- Updated the WaitingView component usage in the DiscussRoute component to remove the 'queuePosition' prop

closes #94 