### PR TITLE
Docker API Gateway

### DIFF
--- a/backend/kubernetes/13 - websocket-api-gateway.yaml
+++ b/backend/kubernetes/13 - websocket-api-gateway.yaml
@@ -6,11 +6,54 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:5173"
-    nginx.ingress.kubernetes.io/enable-websocket: "true"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      set $auth_token $arg_token;
+
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+
+      # Auth request configuration
+      auth_request /_auth_websocket;
+      
+      # Capture auth response headers
+      auth_request_set $auth_user_id $upstream_http_x_user_id;
+      auth_request_set $auth_user_email $upstream_http_x_user_email;
+      auth_request_set $auth_user_name $upstream_http_x_user_name;
+      auth_request_set $auth_user_is_admin $upstream_http_x_user_is_admin;
+      
+      # Forward these headers to the backend service
+      proxy_set_header X-User-Id $auth_user_id;
+      proxy_set_header X-User-Email $auth_user_email;
+      proxy_set_header X-User-Name $auth_user_name;
+      proxy_set_header X-User-Is-Admin $auth_user_is_admin;
+
+    nginx.ingress.kubernetes.io/server-snippet: |
+      # Define the auth location
+      location = /_auth_websocket {
+        internal;
+        proxy_pass http://user-service.g55.svc.cluster.local:8080/api/auth/verify-token;
+        
+        # Standard auth proxy settings
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        
+        # Forward original request details
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_set_header X-Original-Method $request_method;
+        proxy_set_header Host $host;
+        
+        if ($auth_token = "") {
+          return 401;
+        }
+        
+        # Forward original headers that might be needed for auth
+        proxy_set_header Authorization "Bearer $auth_token";
+        proxy_pass_request_headers on;
+      }
+
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
-    nginx.org/websocket-services: "matching-service,room-service,collaborative-editor-service"
 spec:
   rules:
     - host: localhost

--- a/backend/kubernetes/nginx/0-nginx-config-map.yaml
+++ b/backend/kubernetes/nginx/0-nginx-config-map.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+data:
+  allow-snippet-annotations: "true"

--- a/backend/kubernetes/setup.sh
+++ b/backend/kubernetes/setup.sh
@@ -3,6 +3,7 @@
 # Variables
 DOCKER_USERNAME="your_docker_username"
 NAMESPACE="g55"
+INGRESS_NAMESPACE="ingress-nginx"
 SERVICE_NAMES=("service-user" "service-question" "service-matching" "mongoDB" "service-room" "service-history" "service-code-execution" "service-collaborative-editor" "service-video")
 IMAGE_NAMES=("user_service" "question_service" "matching_service" "mongodb" "room_service" "history_service" "code_execution_service" "collaborative_editor_service" "video_service")
 
@@ -42,7 +43,10 @@ for yaml_file in *.yaml; do
   sed -i '' "s/docker_username/$DOCKER_USERNAME/g" "$yaml_file"
 done
 
-# Apply Kubernetes configurations
+echo "Apply API Gateway configuration"
+kubectl apply -f ./nginx/0-nginx-config-map.yaml -n $INGRESS_NAMESPACE
+
+echo "Applying Kubernetes configurations"
 kubectl apply -f . -n $NAMESPACE
 
 # Port-forward Ingress-Nginx service (keep terminal open)

--- a/backend/nginx/conf.d/localhost.conf
+++ b/backend/nginx/conf.d/localhost.conf
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    # Public routes
+    include /etc/nginx/conf.d/public.conf;
+
+    # Private routes
+    include /etc/nginx/conf.d/private.conf;
+
+    # Websocket routes
+    include /etc/nginx/conf.d/websocket.conf;
+}

--- a/backend/nginx/conf.d/private.conf
+++ b/backend/nginx/conf.d/private.conf
@@ -1,0 +1,83 @@
+location = /auth/user {
+    internal;
+    proxy_pass http://backend-service-user:8080/api/auth/verify-token;
+
+    # Don't forward the request body to the auth service
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
+    proxy_set_header X-Original-URI $request_uri;
+
+    # The users auth service requires the Authorization header
+    # with the JWT as the Bearer token
+    proxy_set_header Authorization $http_authorization;
+}
+
+location /api/auth {
+    include includes/cors.conf;
+    include includes/proxy-params.conf;
+
+    auth_request /auth/user;
+    include includes/auth-params.conf;
+
+    proxy_pass http://backend-service-user:8080/api/auth;
+}
+
+location /api/users {
+    include includes/cors.conf;
+    include includes/proxy-params.conf;
+
+    auth_request /auth/user;
+    include includes/auth-params.conf;
+
+    proxy_pass http://backend-service-user:8080/api/users;
+}
+
+location /api/questions {
+    include includes/cors.conf;
+    include includes/proxy-params.conf;
+
+    auth_request /auth/user;
+    include includes/auth-params.conf;
+
+    proxy_pass http://backend-service-question:8080/api/questions;
+}
+
+location /api/matching {
+    include includes/cors.conf;
+    include includes/proxy-params.conf;
+
+    auth_request /auth/user;
+    include includes/auth-params.conf;
+
+    proxy_pass http://backend-service-matching:8080/api/matching;
+}
+
+location /api/rooms {
+    include includes/cors.conf;
+    include includes/proxy-params.conf;
+
+    auth_request /auth/user;
+    include includes/auth-params.conf;
+
+    proxy_pass http://backend-service-room:8080/api/rooms;
+}
+
+location /api/history {
+    include includes/cors.conf;
+    include includes/proxy-params.conf;
+
+    auth_request /auth/user;
+    include includes/auth-params.conf;
+
+    proxy_pass http://backend-service-history:8080/api/history;
+}
+
+location /api/code-execution {
+    include includes/cors.conf;
+    include includes/proxy-params.conf;
+
+    auth_request /auth/user;
+    include includes/auth-params.conf;
+
+    proxy_pass http://backend-service-code-execution:8080/api/code-execution;
+}

--- a/backend/nginx/conf.d/public.conf
+++ b/backend/nginx/conf.d/public.conf
@@ -1,0 +1,49 @@
+# public routes
+
+location /api/users/create {
+    include includes/cors.conf;
+    include includes/proxy-params.conf;
+    proxy_pass http://backend-service-user:8080;
+}
+
+location /api/auth/login {
+    include includes/cors.conf;
+    include includes/proxy-params.conf;
+    proxy_pass http://backend-service-user:8080;
+}
+
+location /api/auth/forgot-password {
+    include includes/cors.conf;
+    include includes/proxy-params.conf;
+    proxy_pass http://backend-service-user:8080;
+}
+
+location /api/auth/reset-password {
+    include includes/cors.conf;
+    include includes/proxy-params.conf;
+    proxy_pass http://backend-service-user:8080;
+}
+
+location /api/auth/verify {
+    include includes/cors.conf;
+    include includes/proxy-params.conf;
+    proxy_pass http://backend-service-user:8080;
+}
+
+location /api/auth/resend-verification {
+    include includes/cors.conf;
+    include includes/proxy-params.conf;
+    proxy_pass http://backend-service-user:8080;
+}
+
+location /api/auth/verify-token {
+    include includes/cors.conf;
+    include includes/proxy-params.conf;
+    proxy_pass http://backend-service-user:8080;
+}
+
+location /api/questions/public {
+    include includes/cors.conf;
+    include includes/proxy-params.conf;
+    proxy_pass http://backend-service-question:8080;
+}

--- a/backend/nginx/conf.d/websocket.conf
+++ b/backend/nginx/conf.d/websocket.conf
@@ -1,0 +1,66 @@
+location = /auth/websocket {
+    internal;
+    proxy_pass http://backend-service-user:8080/api/auth/verify-token;
+
+    # Don't forward the request body to the auth service
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
+    proxy_set_header X-Original-URI $request_uri;
+
+    if ($auth_token = "" ) {
+        return 401;
+    }
+
+    # Set the auth header here because `proxy_set_header`
+    # set in the location is for the proxied request, not the original
+    proxy_set_header Authorization "Bearer $auth_token";
+    # proxy_pass_request_headers on;
+}
+
+location /ws/matching {
+    include includes/cors.conf;
+    include includes/web-socket-params.conf;
+
+    set $auth_token $arg_token;
+
+    auth_request /auth/websocket;
+    include includes/auth-params.conf;
+
+    proxy_pass http://backend-service-matching:8080/ws/matching;
+}
+
+location /ws/rooms {
+    include includes/cors.conf;
+    include includes/web-socket-params.conf;
+
+    set $auth_token $arg_token;
+
+    auth_request /auth/websocket;
+    include includes/auth-params.conf;
+
+    proxy_pass http://backend-service-room:8080/ws/rooms;
+}
+
+location /ws/collaborative-editor {
+    include includes/cors.conf;
+    include includes/web-socket-params.conf;
+
+    set $auth_token $arg_token;
+
+    auth_request /auth/websocket;
+    include includes/auth-params.conf;
+
+    proxy_pass http://backend-service-collaborative-editor:8080/ws/collaborative-editor;
+}
+
+location /ws/signaling {
+    include includes/cors.conf;
+    include includes/web-socket-params.conf;
+
+    set $auth_token $arg_token;
+
+    auth_request /auth/websocket;
+    include includes/auth-params.conf;
+
+    proxy_pass http://backend-service-video:8080/ws/signaling;
+}

--- a/backend/nginx/includes/auth-params.conf
+++ b/backend/nginx/includes/auth-params.conf
@@ -1,0 +1,13 @@
+# Endpoints that require user authentication should include this file
+
+# 1. Capture auth response headers
+auth_request_set $auth_user_id $upstream_http_x_user_id;
+auth_request_set $auth_user_email $upstream_http_x_user_email;
+auth_request_set $auth_user_name $upstream_http_x_user_name;
+auth_request_set $auth_user_is_admin $upstream_http_x_user_is_admin;
+
+# 2. Forward them to the backend
+proxy_set_header X-User-Id $auth_user_id;
+proxy_set_header X-User-Email $auth_user_email;
+proxy_set_header X-User-Name $auth_user_name;
+proxy_set_header X-User-Is-Admin $auth_user_is_admin;

--- a/backend/nginx/includes/cors.conf
+++ b/backend/nginx/includes/cors.conf
@@ -1,0 +1,25 @@
+# CORS configuration
+# We don't want duplicate CORS headesr in the response
+# as it causes an error on the frontend side
+proxy_hide_header 'Access-Control-Allow-Origin';
+
+add_header 'Access-Control-Allow-Origin' 'http://localhost:5173' always;
+add_header 'Access-Control-Allow-Methods'
+    'GET, PUT, POST, DELETE, OPTIONS'
+    always;
+add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type' always;
+add_header 'Access-Control-Allow-Credentials' 'true' always;
+
+# Handle preflight requests (OPTIONS)
+if ($request_method = 'OPTIONS' ) {
+    add_header 'Access-Control-Allow-Origin' 'http://localhost:5173' always;
+    add_header 'Access-Control-Allow-Methods'
+        'GET, PUT, POST, DELETE, OPTIONS'
+        always;
+    add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type' always;
+    add_header 'Access-Control-Allow-Credentials' 'true' always;
+    add_header 'Access-Control-Max-Age' 1728000;
+    add_header 'Content-Type' 'text/plain charset=UTF-8';
+    add_header 'Content-Length' 0;
+    return 204;
+}

--- a/backend/nginx/includes/proxy-params.conf
+++ b/backend/nginx/includes/proxy-params.conf
@@ -1,0 +1,8 @@
+# All proxy locations should include this file
+
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $realip_remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-Port $server_port;

--- a/backend/nginx/includes/web-socket-params.conf
+++ b/backend/nginx/includes/web-socket-params.conf
@@ -1,0 +1,10 @@
+# WebSocket params
+# include this file in the location block for each websocket route
+
+proxy_http_version 1.1;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection "upgrade";
+
+# Set the max timeout for the websocket connection to 1 hour
+proxy_read_timeout 3600;
+proxy_send_timeout 3600;

--- a/backend/nginx/nginx.conf
+++ b/backend/nginx/nginx.conf
@@ -1,0 +1,47 @@
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log notice;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    # Logging Settings
+    log_format main
+        '$remote_addr - $remote_user [$time_local] "$request" '
+        '$status $body_bytes_sent "$http_referer" '
+        '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+
+    # Basic Settings
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+
+    # Gzip Settings
+    gzip on;
+    gzip_disable "msie6";
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain
+        text/css
+        application/json
+        application/javascript
+        text/xml
+        application/xml
+        application/xml+rss
+        text/javascript;
+
+    # Virtual Host Configs
+    include /etc/nginx/conf.d/localhost.conf;
+    include /etc/nginx/sites-enabled/*;
+}

--- a/backend/service-collaborative-editor/src/main/java/g55/cs3219/backend/collaborativeeditorservice/websocket/CollaborativeEditorWebSocketHandler.java
+++ b/backend/service-collaborative-editor/src/main/java/g55/cs3219/backend/collaborativeeditorservice/websocket/CollaborativeEditorWebSocketHandler.java
@@ -7,17 +7,11 @@ import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.lang.NonNull;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.BinaryWebSocketHandler;
-import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriTemplate;
 
 public class CollaborativeEditorWebSocketHandler extends BinaryWebSocketHandler {
@@ -63,9 +57,9 @@ public class CollaborativeEditorWebSocketHandler extends BinaryWebSocketHandler 
         logger.info("Connection closed for session: {}", session.getId());
     }
 
-    private String extractRoom(WebSocketSession session){
+    private String extractRoom(WebSocketSession session) {
         try {
-            if (authenticateUser(session) == null) {
+            if (extractUserId(session) == null) {
                 session.close(CloseStatus.BAD_DATA.withReason("User not authenticated"));
                 return null;
             }
@@ -73,7 +67,7 @@ public class CollaborativeEditorWebSocketHandler extends BinaryWebSocketHandler 
             logger.error("Exception occurred during user authentication: {}", e.getMessage(), e);
             return null;
         }
-        
+
         URI uri = session.getUri();
         if (uri == null) {
             logger.warn("Session URI is null");
@@ -84,49 +78,13 @@ public class CollaborativeEditorWebSocketHandler extends BinaryWebSocketHandler 
         return variables.get("roomId");
     }
 
-    private String authenticateUser(WebSocketSession session) {
-        URI uri = session.getUri();
-        String token = null;
-        String query = null;
-
-        if (uri != null) {
-            query = uri.getQuery();
-            if (query != null && !query.isEmpty()) {
-                token =  UriComponentsBuilder.newInstance().query(query).build().getQueryParams().getFirst("token");
-            } else {
-                logger.warn("No query parameters found or token parameter missing");
-            }
+    private String extractUserId(WebSocketSession session) {
+        String userIdString = session.getHandshakeHeaders().getFirst("X-User-Id");
+        if (userIdString != null) {
+            return userIdString;
         }
-
-        if (token != null) {
-            RestTemplate restTemplate = new RestTemplate();
-            String verifyTokenUrl = "http://user-service.g55.svc.cluster.local:8080/api/auth/verify-token";
-
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("Authorization", "Bearer " + token);
-            HttpEntity<String> entity = new HttpEntity<>(headers);
-
-            try {
-                ResponseEntity<String> response = restTemplate.exchange(
-                        verifyTokenUrl,
-                        HttpMethod.GET,
-                        entity,
-                        String.class
-                );
-
-                logger.info("Response received from verify-token endpoint with status code: {}", response.getStatusCode());
-
-                if (response.getStatusCode().is2xxSuccessful()) {
-                    return response.getBody();
-                } else {
-                    logger.warn("Failed to verify token. Non-successful response received.");
-                }
-            } catch (Exception e) {
-                logger.error("Exception occurred during token verification: {}", e.getMessage(), e);
-            }
-        } else {
-            logger.warn("Token is null, unable to verify");
-        }
+        logger.warn("No userId found in WebSocket handshake headers");
         return null;
     }
+
 }

--- a/backend/service-matching/src/main/java/g55/cs3219/backend/matchingservice/service/MatchingWebSocketHandler.java
+++ b/backend/service-matching/src/main/java/g55/cs3219/backend/matchingservice/service/MatchingWebSocketHandler.java
@@ -1,21 +1,12 @@
 package g55.cs3219.backend.matchingservice.service;
 
-import java.net.URI;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.lang.NonNull;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
-import org.springframework.web.util.UriComponentsBuilder;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.JsonNode;
 
 public class MatchingWebSocketHandler extends TextWebSocketHandler {
 
@@ -29,7 +20,7 @@ public class MatchingWebSocketHandler extends TextWebSocketHandler {
     }
 
     @Override
-    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+    public void afterConnectionEstablished(@NonNull WebSocketSession session) throws Exception {
         String userId = extractUserId(session);
         logger.info("WebSocket connection established for user: {}", userId);
         if (userId != null) {
@@ -40,12 +31,11 @@ public class MatchingWebSocketHandler extends TextWebSocketHandler {
     }
 
     @Override
-    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
-        // Handle incoming messages if needed
+    protected void handleTextMessage(@NonNull WebSocketSession session, @NonNull TextMessage message) throws Exception {
     }
 
     @Override
-    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+    public void afterConnectionClosed(@NonNull WebSocketSession session, @NonNull CloseStatus status) throws Exception {
         String userId = extractUserId(session);
         logger.info("WebSocket connection closed for user: {}", userId);
         if (userId != null) {
@@ -55,67 +45,11 @@ public class MatchingWebSocketHandler extends TextWebSocketHandler {
     }
 
     private String extractUserId(WebSocketSession session) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode jsonNode = null;
-        try {
-            jsonNode = objectMapper.readTree(authenticateUser(session));
-            if (jsonNode.has("id")) {
-                String userId = jsonNode.get("id").asText();
-                return userId;
-            } else {
-                logger.warn("Response JSON does not contain 'id' field");
-            }
-        } catch (Exception e) {
-            logger.error("Exception occurred during token verification: {}", e.getMessage(), e);
+        String userIdString = session.getHandshakeHeaders().getFirst("X-User-Id");
+        if (userIdString != null) {
+            return userIdString;
         }
-
-        logger.warn("Returning null, userId extraction failed");
-        return null;
-    }
-
-    private String authenticateUser(WebSocketSession session) {
-        URI uri = session.getUri();
-        String token = null;
-        String query = null;
-
-        if (uri != null) {
-            query = uri.getQuery();
-            if (query != null && !query.isEmpty()) {
-                token =  UriComponentsBuilder.newInstance().query(query).build().getQueryParams().getFirst("token");
-            } else {
-                logger.warn("No query parameters found or token parameter missing");
-            }
-        }
-
-        if (token != null) {
-            RestTemplate restTemplate = new RestTemplate();
-            String verifyTokenUrl = "http://user-service.g55.svc.cluster.local:8080/api/auth/verify-token";
-
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("Authorization", "Bearer " + token);
-            HttpEntity<String> entity = new HttpEntity<>(headers);
-
-            try {
-                ResponseEntity<String> response = restTemplate.exchange(
-                        verifyTokenUrl,
-                        HttpMethod.GET,
-                        entity,
-                        String.class
-                );
-
-                logger.info("Response received from verify-token endpoint with status code: {}", response.getStatusCode());
-
-                if (response.getStatusCode().is2xxSuccessful()) {
-                    return response.getBody();
-                } else {
-                    logger.warn("Failed to verify token. Non-successful response received.");
-                }
-            } catch (Exception e) {
-                logger.error("Exception occurred during token verification: {}", e.getMessage(), e);
-            }
-        } else {
-            logger.warn("Token is null, unable to verify");
-        }
+        logger.warn("No userId found in WebSocket handshake headers");
         return null;
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,41 @@
 services:
-  frontend:
-    build:
-      context: ./frontend
-    container_name: frontend
+  # frontend:
+  #   build:
+  #     context: ./frontend
+  #   container_name: frontend
+  #   ports:
+  #     - '5173:5173'
+  #   networks:
+  #     - app-network
+  #   depends_on:
+  #     - backend-service-question
+  #     - backend-service-user
+  #     - backend-service-matching
+
+  nginx:
+    image: nginx:alpine
     ports:
-      - '5173:5173'
+      - '8080:80'
+    volumes:
+      - ./backend/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./backend/nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./backend/nginx/includes:/etc/nginx/includes:ro
     networks:
       - app-network
     depends_on:
-      - backend-service-question
       - backend-service-user
+      - backend-service-question
       - backend-service-matching
+      - backend-service-room
+      - backend-service-history
+      - backend-service-collaborative-editor
+      - backend-service-code-execution
+      - backend-service-video
 
   backend-service-question:
     build:
       context: ./backend/service-question
     container_name: backend-service-question
-    ports:
-      - '8080:8080'
     networks:
       - app-network
     environment:
@@ -29,8 +47,6 @@ services:
   mongodb:
     image: mongo:latest
     container_name: mongodb
-    ports:
-      - '27017:27017'
     networks:
       - app-network
     environment:
@@ -44,8 +60,6 @@ services:
     build:
       context: ./backend/service-user
     container_name: backend-service-user
-    ports:
-      - '8081:8080'
     networks:
       - app-network
     depends_on:
@@ -58,8 +72,6 @@ services:
   backend-service-user-db:
     image: postgres:16-alpine
     container_name: backend-service-user-db
-    ports:
-      - '5433:5432'
     networks:
       - app-network
     environment:
@@ -74,8 +86,6 @@ services:
     build:
       context: ./backend/service-matching
     container_name: backend-service-matching
-    ports:
-      - '8082:8080'
     networks:
       - app-network
     environment:
@@ -88,8 +98,6 @@ services:
     build:
       context: ./backend/service-room
     container_name: backend-service-room
-    ports:
-      - '8083:8080'
     networks:
       - app-network
     depends_on:
@@ -107,8 +115,6 @@ services:
   backend-service-room-db:
     image: postgres:16-alpine
     container_name: backend-service-room-db
-    ports:
-      - '5434:5432'
     networks:
       - app-network
     environment:
@@ -122,9 +128,6 @@ services:
   rabbitmq:
     image: rabbitmq:4.0-management
     container_name: rabbitmq
-    ports:
-      - '5672:5672'
-      - '15672:15672'
     networks:
       - app-network
     environment:
@@ -135,8 +138,6 @@ services:
     build:
       context: ./backend/service-history
     container_name: backend-service-history
-    ports:
-      - '8084:8080'
     networks:
       - app-network
     environment:
@@ -148,8 +149,6 @@ services:
   backend-service-history-db:
     image: mongo:latest
     container_name: backend-service-history-db
-    ports:
-      - '27018:27017'
     networks:
       - app-network
     environment:
@@ -163,8 +162,6 @@ services:
     build:
       context: ./backend/service-collaborative-editor
     container_name: backend-service-collaborative-editor
-    ports:
-      - '8085:8080'
     networks:
       - app-network
 
@@ -175,8 +172,6 @@ services:
       NODE_ENV: production
       PORT: 8080
     container_name: backend-service-code-execution
-    ports:
-      - '8086:8080'
     networks:
       - app-network
     deploy:
@@ -190,11 +185,8 @@ services:
     build:
       context: ./backend/service-video
     container_name: backend-service-video
-    ports:
-      - '8087:8080'
     networks:
       - app-network
-
 
 networks:
   app-network:

--- a/frontend/src/hooks/useRoom.tsx
+++ b/frontend/src/hooks/useRoom.tsx
@@ -37,7 +37,6 @@ export function useRoom(roomId: string | undefined) {
       const token = getToken();
       const response = await fetch(`${BACKEND_URL_ROOM}/${roomId}`, {
         headers: {
-          "X-User-Id": auth.user.userId.toString(),
           Authorization: `Bearer ${token}`,
         },
       });


### PR DESCRIPTION
## PR Description

Fixes #148 
This PR adds nginx as the docker-compose and sets up the nginx configuration to run the API Gateway for docker compose.

The advantage of doing this is to avoid having to spin up kubernetes each time we want to do local testing / development.

### WebSocket Auth

This PR also fixes the authentication for websocket connections. Previously, the websocket auth was handled by each service's own WebSocketHandler separately, which leads to duplication of code.

However, this PR adds a configuration snippet that allows for the websocket auth to be handled by the API Gateway, as long as the user passes in the JWT as a **query param**. We pass in a query param as the frontend is unable to attach any custom headers to a websocket connection (including the `Authorization` header).

Because the `auth` module does not forward query params in the auth subrequest, we capture the argument in a variable first, and then attach it as bearer token before forwarding to the auth service.

```nginx
location = /auth/websocket {
    # ...
    # Set the auth header here because `proxy_set_header`
    # set in the location is for the proxied request, not the original
    proxy_set_header Authorization "Bearer $auth_token";
}

location /ws/matching {
    #...

    # Capture as variable because args are not passed to the auth subrequest
    set $auth_token $arg_token;

    auth_request /auth/websocket;
    auth_request_set ....

    proxy_pass http://backend-service-matching:8080/ws/matching;
}
```
